### PR TITLE
Unify return type across different actions using a `Result` struct

### DIFF
--- a/lib/ethers/contract.ex
+++ b/lib/ethers/contract.ex
@@ -240,9 +240,7 @@ defmodule Ethers.Contract do
       #{unquote(document_types(selector.returns))}
       """
       @spec unquote(name)(unquote_splicing(func_input_types), Keyword.t()) ::
-              {:ok, [unquote(func_return_typespec)]}
-              | {:ok, Ethers.Types.t_hash()}
-              | {:ok, Ethers.Contract.t_function_output()}
+              {:ok, Result.t([unquote(func_return_typespec)])}
               | {:error, term()}
       def unquote(name)(unquote_splicing(func_args), unquote(overrides)) do
         args =
@@ -271,9 +269,7 @@ defmodule Ethers.Contract do
       Same as `#{unquote(name)}/#{unquote(Enum.count(func_args) + 1)}` but raises `Ethers.ExecutionError` on errors.
       """
       @spec unquote(bang_fun_name)(unquote_splicing(func_input_types), Keyword.t()) ::
-              [unquote(func_return_typespec)]
-              | Ethers.Types.t_hash()
-              | Ethers.Contract.t_function_output()
+              Result.t([unquote(func_return_typespec)])
               | no_return
       def unquote(bang_fun_name)(unquote_splicing(func_args), unquote(overrides)) do
         case unquote(name)(unquote_splicing(func_args), overrides) do

--- a/lib/ethers/contract.ex
+++ b/lib/ethers/contract.ex
@@ -42,13 +42,9 @@ defmodule Ethers.Contract do
 
   require Ethers.ContractHelpers
   import Ethers.ContractHelpers
+  alias Ethers.Result
 
   @type action :: :call | :send | :prepare
-  @type t_function_output :: %{
-          data: binary,
-          to: Ethers.Types.t_address(),
-          selector: ABI.FunctionSelector.t()
-        }
   @type t_event_output :: %{
           topics: [binary],
           address: Ethers.Types.t_address(),
@@ -145,9 +141,7 @@ defmodule Ethers.Contract do
 
   @doc false
   @spec perform_action(action(), map, Keyword.t(), Keyword.t()) ::
-          {:ok, [term]}
-          | {:ok, Ethers.Types.t_hash()}
-          | {:ok, Ethers.Contract.t_function_output()}
+          {:ok, Result.t()}
           | {:error, term()}
   def perform_action(action, params, overrides \\ [], rpc_opts \\ [])
 
@@ -161,7 +155,7 @@ defmodule Ethers.Contract do
     do: Ethers.RPC.estimate_gas(params, overrides, rpc_opts)
 
   def perform_action(:prepare, params, overrides, _rpc_opts),
-    do: {:ok, Enum.into(overrides, params)}
+    do: Ethers.RPC.prepare_params(params, overrides)
 
   def perform_action(action, _params, _overrides, _rpc_opts),
     do: raise("#{__MODULE__} Invalid action: #{inspect(action)}")

--- a/lib/ethers/name_service.ex
+++ b/lib/ethers/name_service.ex
@@ -6,6 +6,7 @@ defmodule Ethers.NameService do
   import Ethers, only: [keccak_module: 0]
 
   alias Ethers.Contracts.ENS
+  alias Ethers.Result
 
   @null_address "0x0000000000000000000000000000000000000000"
 
@@ -30,11 +31,13 @@ defmodule Ethers.NameService do
   def resolve(name, opts \\ []) do
     name_hash = name_hash(name)
 
-    with {:ok, [resolver]} when resolver != @null_address <- ENS.resolver(name_hash, opts),
-         {:ok, [addr]} <- ENS.Resolver.addr(name_hash, Keyword.merge(opts, to: resolver)) do
+    with {:ok, %Result{return_values: [resolver]}} when resolver != @null_address <-
+           ENS.resolver(name_hash, opts),
+         {:ok, %Result{return_values: [addr]}} <-
+           ENS.Resolver.addr(name_hash, Keyword.merge(opts, to: resolver)) do
       {:ok, addr}
     else
-      {:ok, [@null_address]} -> {:error, :domain_not_found}
+      {:ok, %Result{return_values: [@null_address]}} -> {:error, :domain_not_found}
       {:error, _} = error -> error
     end
   end

--- a/lib/ethers/result.ex
+++ b/lib/ethers/result.ex
@@ -22,13 +22,12 @@ defmodule Ethers.Result do
           Types.t_hash() | nil
         ) :: t()
   def new(params, return_values, gas_estimate, transaction_hash) do
-    {:ok,
-     %__MODULE__{
-       to: params[:to],
-       data: params.data,
-       return_values: return_values,
-       gas_estimate: gas_estimate || params[:gas],
-       transaction_hash: transaction_hash
-     }}
+    %__MODULE__{
+      to: params[:to],
+      data: params.data,
+      return_values: return_values,
+      gas_estimate: gas_estimate || params[:gas],
+      transaction_hash: transaction_hash
+    }
   end
 end

--- a/lib/ethers/result.ex
+++ b/lib/ethers/result.ex
@@ -3,22 +3,23 @@ defmodule Ethers.Result do
   Result struct which holds information regarding calls and transactions.
   """
 
-  alias Ether.Types
+  alias Ethers.Types
 
   defstruct [:transaction_hash, :return_values, :gas_estimate, :to, :data]
 
-  @type t :: %__MODULE__{
+  @type t(return_values_type) :: %__MODULE__{
           transaction_hash: Types.t_hash() | nil,
           gas_estimate: non_neg_integer() | :not_estimated,
-          return_values: [term()] | nil,
+          return_values: return_values_type | nil,
           to: Types.t_address() | nil,
           data: binary()
         }
+  @type t :: t([term()])
 
   @spec new(
           map(),
-          [term()] | :not_loaded,
-          non_neg_integer() | :not_estimated,
+          [term()] | nil,
+          non_neg_integer() | :not_estimated | nil,
           Types.t_hash() | nil
         ) :: t()
   def new(params, return_values, gas_estimate, transaction_hash) do
@@ -26,7 +27,7 @@ defmodule Ethers.Result do
       to: params[:to],
       data: params.data,
       return_values: return_values,
-      gas_estimate: gas_estimate || params[:gas],
+      gas_estimate: gas_estimate || params[:gas] || :not_estimated,
       transaction_hash: transaction_hash
     }
   end

--- a/lib/ethers/result.ex
+++ b/lib/ethers/result.ex
@@ -11,7 +11,7 @@ defmodule Ethers.Result do
           transaction_hash: Types.t_hash() | nil,
           gas_estimate: non_neg_integer() | :not_estimated,
           gas_used: non_neg_integer() | :not_loaded | nil,
-          return_values: [term()] | :not_loaded,
+          return_values: [term()] | nil,
           to: Types.t_address() | nil,
           data: binary()
         }

--- a/lib/ethers/result.ex
+++ b/lib/ethers/result.ex
@@ -5,12 +5,11 @@ defmodule Ethers.Result do
 
   alias Ether.Types
 
-  defstruct [:transaction_hash, :return_values, :gas_estimate, :gas_used, :to, :data]
+  defstruct [:transaction_hash, :return_values, :gas_estimate, :to, :data]
 
   @type t :: %__MODULE__{
           transaction_hash: Types.t_hash() | nil,
           gas_estimate: non_neg_integer() | :not_estimated,
-          gas_used: non_neg_integer() | :not_loaded | nil,
           return_values: [term()] | nil,
           to: Types.t_address() | nil,
           data: binary()

--- a/lib/ethers/result.ex
+++ b/lib/ethers/result.ex
@@ -1,0 +1,35 @@
+defmodule Ethers.Result do
+  @moduledoc """
+  Result struct which holds information regarding calls and transactions.
+  """
+
+  alias Ether.Types
+
+  defstruct [:transaction_hash, :return_values, :gas_estimate, :gas_used, :to, :data]
+
+  @type t :: %__MODULE__{
+          transaction_hash: Types.t_hash() | nil,
+          gas_estimate: non_neg_integer() | :not_estimated,
+          gas_used: non_neg_integer() | :not_loaded | nil,
+          return_values: [term()] | :not_loaded,
+          to: Types.t_address() | nil,
+          data: binary()
+        }
+
+  @spec new(
+          map(),
+          [term()] | :not_loaded,
+          non_neg_integer() | :not_estimated,
+          Types.t_hash() | nil
+        ) :: t()
+  def new(params, return_values, gas_estimate, transaction_hash) do
+    {:ok,
+     %__MODULE__{
+       to: params[:to],
+       data: params.data,
+       return_values: return_values,
+       gas_estimate: gas_estimate || params[:gas],
+       transaction_hash: transaction_hash
+     }}
+  end
+end

--- a/lib/ethers/rpc.ex
+++ b/lib/ethers/rpc.ex
@@ -12,7 +12,7 @@ defmodule Ethers.RPC do
   @doc """
   Returns the prepared parameters with the overrides applied and internals removed.
   """
-  @spec prepare_params(map(), map()) :: Result.t()
+  @spec prepare_params(map(), map()) :: {:ok, Result.t()}
   def prepare_params(params, overrides \\ %{}) do
     params = do_prepare_params(params, overrides)
     {:ok, Result.new(params, nil, :not_estimated, nil)}

--- a/lib/ethers/rpc.ex
+++ b/lib/ethers/rpc.ex
@@ -15,7 +15,7 @@ defmodule Ethers.RPC do
   @spec prepare_params(map(), map()) :: Result.t()
   def prepare_params(params, overrides \\ %{}) do
     params = do_prepare_params(params, overrides)
-    Result.new(params, nil, :not_estimated, nil)
+    {:ok, Result.new(params, nil, :not_estimated, nil)}
   end
 
   @doc """
@@ -54,7 +54,7 @@ defmodule Ethers.RPC do
           |> Enum.zip(selector.returns)
           |> Enum.map(fn {return, type} -> Utils.human_arg(return, type) end)
 
-        Result.new(params, returns, :not_estimated, nil)
+        {:ok, Result.new(params, returns, :not_estimated, nil)}
 
       {:ok, "0x"} ->
         {:error, :unknown}
@@ -94,7 +94,7 @@ defmodule Ethers.RPC do
 
     with {:ok, params} <- Utils.maybe_add_gas_limit(params, opts),
          {:ok, tx} when valid_result(tx) <- eth_send_transaction(params, opts) do
-      Result.new(params, nil, nil, tx)
+      {:ok, Result.new(params, nil, nil, tx)}
     else
       {:ok, "0x"} ->
         {:error, :unknown}
@@ -109,7 +109,7 @@ defmodule Ethers.RPC do
 
     with {:ok, gas_hex} <- eth_estimate_gas(params, opts),
          {:ok, estimated_gas} <- Utils.hex_to_integer(gas_hex) do
-      Result.new(params, nil, estimated_gas, nil)
+      {:ok, Result.new(params, nil, estimated_gas, nil)}
     end
   end
 

--- a/lib/ethers/rpc.ex
+++ b/lib/ethers/rpc.ex
@@ -15,7 +15,7 @@ defmodule Ethers.RPC do
   @spec prepare_params(map(), map()) :: Result.t()
   def prepare_params(params, overrides \\ %{}) do
     params = do_prepare_params(params, overrides)
-    Result.new(params, :not_loaded, :not_estimated, nil)
+    Result.new(params, nil, :not_estimated, nil)
   end
 
   @doc """
@@ -94,7 +94,7 @@ defmodule Ethers.RPC do
 
     with {:ok, params} <- Utils.maybe_add_gas_limit(params, opts),
          {:ok, tx} when valid_result(tx) <- eth_send_transaction(params, opts) do
-      Result.new(params, :not_loaded, nil, tx)
+      Result.new(params, nil, nil, tx)
     else
       {:ok, "0x"} ->
         {:error, :unknown}
@@ -109,7 +109,7 @@ defmodule Ethers.RPC do
 
     with {:ok, gas_hex} <- eth_estimate_gas(params, opts),
          {:ok, estimated_gas} <- Utils.hex_to_integer(gas_hex) do
-      Result.new(params, :not_loaded, estimated_gas, nil)
+      Result.new(params, nil, estimated_gas, nil)
     end
   end
 

--- a/lib/ethers/rpc.ex
+++ b/lib/ethers/rpc.ex
@@ -3,7 +3,7 @@ defmodule Ethers.RPC do
   RPC Methods for interacting with the Ethereum blockchain
   """
 
-  alias Ethers.{Utils, Result}
+  alias Ethers.{Result, Utils}
 
   defguardp valid_result(bin) when bin != "0x"
 

--- a/lib/ethers/utils.ex
+++ b/lib/ethers/utils.ex
@@ -154,7 +154,7 @@ defmodule Ethers.Utils do
   end
 
   def maybe_add_gas_limit(params, opts) do
-    with {:ok, gas} <- RPC.estimate_gas(params, opts) do
+    with {:ok, %{gas_estimate: gas}} <- RPC.estimate_gas(params, opts) do
       mult = (opts[:mult] || 100) + 1000
       gas = div(mult * gas, 1000)
       {:ok, Map.put(params, :gas, gas)}

--- a/test/ethers/owner_contract_test.exs
+++ b/test/ethers/owner_contract_test.exs
@@ -17,6 +17,7 @@ defmodule Ethers.OwnerContractTest do
     assert {:ok, tx_hash} = Ethers.deploy(OwnerContract, init_params, %{from: @from})
     assert {:ok, address} = Ethers.deployed_address(tx_hash)
 
-    assert {:ok, [@sample_address]} = OwnerContract.get_owner(to: address)
+    assert {:ok, %Ethers.Result{return_values: [@sample_address]}} =
+             OwnerContract.get_owner(to: address)
   end
 end

--- a/test/ethers/registry_contract_test.exs
+++ b/test/ethers/registry_contract_test.exs
@@ -8,6 +8,7 @@ defmodule Ethers.RegistryContractTest do
   doctest Ethers.Contract
 
   alias Ethers.Contract.Test.RegistryContract
+  alias Ethers.Result, as: R
 
   @from "0x90f8bf6a479f320ead074411a4b0e7944ea8c9c1"
 
@@ -19,11 +20,11 @@ defmodule Ethers.RegistryContractTest do
     end
 
     test "can call functions returning structs", %{address: address} do
-      {:ok, [{"", 0}]} = RegistryContract.info(@from, to: address)
+      {:ok, %R{return_values: [{"", 0}]}} = RegistryContract.info(@from, to: address)
 
-      {:ok, _tx_hash} = RegistryContract.register({"alisina", 27}, from: @from, to: address)
+      {:ok, %R{}} = RegistryContract.register({"alisina", 27}, from: @from, to: address)
 
-      {:ok, [{"alisina", 27}]} = RegistryContract.info(@from, to: address)
+      {:ok, %R{return_values: [{"alisina", 27}]}} = RegistryContract.info(@from, to: address)
     end
   end
 

--- a/test/ethers/types_contract_test.exs
+++ b/test/ethers/types_contract_test.exs
@@ -7,6 +7,8 @@ defmodule Ethers.TypesContractTest do
   use ExUnit.Case
   doctest Ethers.Contract
 
+  alias Ethers.Result, as: R
+
   alias Ethers.Contract.Test.TypesContract
 
   @from "0x90F8bf6A479f320ead074411a4B0e7944Ea8c9C1"
@@ -16,59 +18,72 @@ defmodule Ethers.TypesContractTest do
 
   describe "encode/decode" do
     test "uint types", %{address: address} do
-      assert {:ok, [100]} = TypesContract.get_uint8(100, to: address)
-      assert {:ok, [100]} = TypesContract.get_uint16(100, to: address)
-      assert {:ok, [100]} = TypesContract.get_uint32(100, to: address)
-      assert {:ok, [100]} = TypesContract.get_uint64(100, to: address)
-      assert {:ok, [100]} = TypesContract.get_uint128(100, to: address)
-      assert {:ok, [100]} = TypesContract.get_uint256(100, to: address)
+      assert {:ok, %R{return_values: [100]}} = TypesContract.get_uint8(100, to: address)
+      assert {:ok, %R{return_values: [100]}} = TypesContract.get_uint16(100, to: address)
+      assert {:ok, %R{return_values: [100]}} = TypesContract.get_uint32(100, to: address)
+      assert {:ok, %R{return_values: [100]}} = TypesContract.get_uint64(100, to: address)
+      assert {:ok, %R{return_values: [100]}} = TypesContract.get_uint128(100, to: address)
+      assert {:ok, %R{return_values: [100]}} = TypesContract.get_uint256(100, to: address)
     end
 
     test "int types", %{address: address} do
-      assert {:ok, [-101]} = TypesContract.get_int8(-101, to: address)
-      assert {:ok, [-101]} = TypesContract.get_int16(-101, to: address)
-      assert {:ok, [-101]} = TypesContract.get_int32(-101, to: address)
-      assert {:ok, [-101]} = TypesContract.get_int64(-101, to: address)
-      assert {:ok, [-101]} = TypesContract.get_int128(-101, to: address)
-      assert {:ok, [-101]} = TypesContract.get_int256(-101, to: address)
+      assert {:ok, %R{return_values: [-101]}} = TypesContract.get_int8(-101, to: address)
+      assert {:ok, %R{return_values: [-101]}} = TypesContract.get_int16(-101, to: address)
+      assert {:ok, %R{return_values: [-101]}} = TypesContract.get_int32(-101, to: address)
+      assert {:ok, %R{return_values: [-101]}} = TypesContract.get_int64(-101, to: address)
+      assert {:ok, %R{return_values: [-101]}} = TypesContract.get_int128(-101, to: address)
+      assert {:ok, %R{return_values: [-101]}} = TypesContract.get_int256(-101, to: address)
     end
 
     test "boolean type", %{address: address} do
-      assert {:ok, [false]} = TypesContract.get_bool(false, to: address)
-      assert {:ok, [true]} = TypesContract.get_bool(true, to: address)
+      assert {:ok, %R{return_values: [false]}} = TypesContract.get_bool(false, to: address)
+      assert {:ok, %R{return_values: [true]}} = TypesContract.get_bool(true, to: address)
     end
 
     test "string type", %{address: address} do
-      assert {:ok, ["a string"]} = TypesContract.get_string("a string", to: address)
-      assert {:ok, [""]} = TypesContract.get_string("", to: address)
-      assert {:ok, [<<0>>]} = TypesContract.get_string(<<0>>, to: address)
+      assert {:ok, %R{return_values: ["a string"]}} =
+               TypesContract.get_string("a string", to: address)
+
+      assert {:ok, %R{return_values: [""]}} = TypesContract.get_string("", to: address)
+      assert {:ok, %R{return_values: [<<0>>]}} = TypesContract.get_string(<<0>>, to: address)
     end
 
     test "address type", %{address: address} do
-      assert {:ok, [@sample_address]} = TypesContract.get_address(@sample_address, to: address)
+      assert {:ok, %R{return_values: [@sample_address]}} =
+               TypesContract.get_address(@sample_address, to: address)
     end
 
     test "bytes type", %{address: address} do
-      assert {:ok, [<<0, 1, 2, 3>>]} = TypesContract.get_bytes(<<0, 1, 2, 3>>, to: address)
-      assert {:ok, [<<1234::1024>>]} = TypesContract.get_bytes(<<1234::1024>>, to: address)
+      assert {:ok, %R{return_values: [<<0, 1, 2, 3>>]}} =
+               TypesContract.get_bytes(<<0, 1, 2, 3>>, to: address)
+
+      assert {:ok, %R{return_values: [<<1234::1024>>]}} =
+               TypesContract.get_bytes(<<1234::1024>>, to: address)
     end
 
     test "fixed bytes type", %{address: address} do
-      assert {:ok, [<<1>>]} = TypesContract.get_bytes1(<<1>>, to: address)
-      assert {:ok, [<<1::20*8>>]} = TypesContract.get_bytes20(<<1::20*8>>, to: address)
-      assert {:ok, [<<1::32*8>>]} = TypesContract.get_bytes32(<<1::32*8>>, to: address)
+      assert {:ok, %R{return_values: [<<1>>]}} = TypesContract.get_bytes1(<<1>>, to: address)
+
+      assert {:ok, %R{return_values: [<<1::20*8>>]}} =
+               TypesContract.get_bytes20(<<1::20*8>>, to: address)
+
+      assert {:ok, %R{return_values: [<<1::32*8>>]}} =
+               TypesContract.get_bytes32(<<1::32*8>>, to: address)
     end
 
     test "struct type", %{address: address} do
-      assert {:ok, [{100, -101, @sample_address}]} =
+      assert {:ok, %R{return_values: [{100, -101, @sample_address}]}} =
                TypesContract.get_struct({100, -101, @sample_address}, to: address)
     end
 
     test "array type", %{address: address} do
-      assert {:ok, [[1, 2, -3]]} = TypesContract.get_int256_array([1, 2, -3], to: address)
-      assert {:ok, [[100, 2, 4]]} = TypesContract.get_fixed_uint_array([100, 2, 4], to: address)
+      assert {:ok, %R{return_values: [[1, 2, -3]]}} =
+               TypesContract.get_int256_array([1, 2, -3], to: address)
 
-      assert {:ok, [[{5, -10, @sample_address}, {1, 900, @sample_address}]]} =
+      assert {:ok, %R{return_values: [[100, 2, 4]]}} =
+               TypesContract.get_fixed_uint_array([100, 2, 4], to: address)
+
+      assert {:ok, %R{return_values: [[{5, -10, @sample_address}, {1, 900, @sample_address}]]}} =
                TypesContract.get_struct_array(
                  [{5, -10, @sample_address}, {1, 900, @sample_address}],
                  to: address


### PR DESCRIPTION
Related to https://github.com/elixir-lang/elixir/pull/12905

### Tasks
- [x] Create the `Result` struct and the initializer.
- [x] Return a `Result` struct on all actions.
- [ ] Change all typespecs for dynamic contracts.
- [ ] Update README.md and examples

Closes #16