### PR TITLE
Fix RPC options and client overriding

### DIFF
--- a/lib/ethers.ex
+++ b/lib/ethers.ex
@@ -100,7 +100,7 @@ defmodule Ethers do
   @spec estimate_gas(map(), Keyword.t()) ::
           {:ok, non_neg_integer()} | {:error, :gas_estimation_failed}
   def estimate_gas(params, opts \\ []) do
-    RPC.estimate_gas(params, [], opts)
+    RPC.estimate_gas(params, opts)
   end
 
   @doc """

--- a/lib/ethers/contract.ex
+++ b/lib/ethers/contract.ex
@@ -144,26 +144,26 @@ defmodule Ethers.Contract do
   end
 
   @doc false
-  @spec perform_action(action(), map, Keyword.t(), Keyword.t()) ::
+  @spec perform_action(action(), map, Keyword.t()) ::
           {:ok, [term]}
           | {:ok, Ethers.Types.t_hash()}
           | {:ok, Ethers.Contract.t_function_output()}
           | {:error, term()}
-  def perform_action(action, params, overrides \\ [], rpc_opts \\ [])
+  def perform_action(action, params, overrides \\ [])
 
-  def perform_action(:call, params, overrides, rpc_opts),
-    do: Ethers.RPC.call(params, overrides, rpc_opts)
+  def perform_action(:call, params, overrides),
+    do: Ethers.RPC.call(params, overrides)
 
-  def perform_action(:send, params, overrides, rpc_opts),
-    do: Ethers.RPC.send(params, overrides, rpc_opts)
+  def perform_action(:send, params, overrides),
+    do: Ethers.RPC.send(params, overrides)
 
-  def perform_action(:estimate_gas, params, overrides, rpc_opts),
-    do: Ethers.RPC.estimate_gas(params, overrides, rpc_opts)
+  def perform_action(:estimate_gas, params, overrides),
+    do: Ethers.RPC.estimate_gas(params, overrides)
 
-  def perform_action(:prepare, params, overrides, _rpc_opts),
+  def perform_action(:prepare, params, overrides),
     do: {:ok, Enum.into(overrides, params)}
 
-  def perform_action(action, _params, _overrides, _rpc_opts),
+  def perform_action(action, _params, _overrides),
     do: raise("#{__MODULE__} Invalid action: #{inspect(action)}")
 
   ## Helpers
@@ -267,10 +267,9 @@ defmodule Ethers.Contract do
           to: __MODULE__.default_address()
         }
 
-        {rpc_opts, overrides} = Keyword.pop(overrides, :rpc_opts, [])
         {action, overrides} = Keyword.pop(overrides, :action, unquote(default_action))
 
-        Ethers.Contract.perform_action(action, params, overrides, rpc_opts)
+        Ethers.Contract.perform_action(action, params, overrides)
       end
 
       @doc """

--- a/lib/ethers/rpc.ex
+++ b/lib/ethers/rpc.ex
@@ -8,6 +8,7 @@ defmodule Ethers.RPC do
   defguardp valid_result(bin) when bin != "0x"
 
   @internal_params [:selector]
+  @option_keys [:rpc_client, :rpc_opts, :block]
 
   @doc """
   Makes an eth_call to with the given data and overrides, Than parses
@@ -30,9 +31,11 @@ defmodule Ethers.RPC do
       {:ok, [100000000000000]}
   """
   @spec call(map, Keyword.t()) :: {:ok, [...]} | {:error, term()}
-  def call(params, overrides \\ [], opts \\ [])
+  def call(params, overrides \\ [])
 
-  def call(%{data: _, selector: selector} = params, overrides, opts) do
+  def call(%{data: _, selector: selector} = params, overrides) do
+    {opts, overrides} = Keyword.split(overrides, @option_keys)
+
     block = Keyword.get(opts, :block, "latest")
 
     params =
@@ -81,9 +84,11 @@ defmodule Ethers.RPC do
       {:ok, transaction_bin}
   """
   @spec send(map, Keyword.t()) :: {:ok, String.t()} | {:error, term()}
-  def send(params, overrides \\ [], opts \\ [])
+  def send(params, overrides \\ [])
 
-  def send(params, overrides, opts) do
+  def send(params, overrides) do
+    {opts, overrides} = Keyword.split(overrides, @option_keys)
+
     params =
       overrides
       |> Enum.into(params)
@@ -101,7 +106,9 @@ defmodule Ethers.RPC do
     end
   end
 
-  def estimate_gas(params, overrides \\ [], opts \\ []) do
+  def estimate_gas(params, overrides \\ []) do
+    {opts, overrides} = Keyword.split(overrides, @option_keys)
+
     params =
       overrides
       |> Enum.into(params)
@@ -137,7 +144,6 @@ defmodule Ethers.RPC do
   end
 
   def eth_estimate_gas(params, opts \\ []) when is_map(params) do
-    params = Map.drop(params, @internal_params)
     {rpc_client, rpc_opts} = rpc_info(opts)
 
     rpc_client.eth_estimate_gas(params, rpc_opts)

--- a/test/ethers/owner_contract_test.exs
+++ b/test/ethers/owner_contract_test.exs
@@ -19,4 +19,30 @@ defmodule Ethers.OwnerContractTest do
 
     assert {:ok, [@sample_address]} = OwnerContract.get_owner(to: address)
   end
+
+  describe "overriding RPC options" do
+    test "can override RPC client" do
+      init_params = OwnerContract.constructor(@sample_address)
+
+      assert {:ok, "tx_hash"} =
+               Ethers.deploy(OwnerContract, init_params, %{from: @from},
+                 rpc_client: Ethers.TestRPCModule
+               )
+    end
+
+    test "can override RPC options" do
+      init_params = OwnerContract.constructor(@sample_address)
+      assert {:ok, tx_hash} = Ethers.deploy(OwnerContract, init_params, %{from: @from})
+      assert {:ok, address} = Ethers.deployed_address(tx_hash)
+
+      assert {:ok, [@sample_address]} =
+               OwnerContract.get_owner(
+                 to: address,
+                 rpc_client: Ethers.TestRPCModule,
+                 rpc_opts: [send_back_to_pid: self()]
+               )
+
+      assert_receive :eth_call
+    end
+  end
 end

--- a/test/support/test_rpc_module.ex
+++ b/test/support/test_rpc_module.ex
@@ -1,0 +1,19 @@
+defmodule Ethers.TestRPCModule do
+  @moduledoc false
+
+  def eth_estimate_gas(_params, _opts) do
+    {:ok, "0x100"}
+  end
+
+  def eth_send_transaction(_params, _opts) do
+    {:ok, "tx_hash"}
+  end
+
+  def eth_call(params, block, opts) do
+    if pid = opts[:send_back_to_pid] do
+      send(pid, :eth_call)
+    end
+
+    Ethereumex.HttpClient.eth_call(params, block, opts)
+  end
+end


### PR DESCRIPTION
`rpc_client` and `rpc_opts` options did not have any effect after the last update.