### PR TITLE
Return structs in generated functions and event filters

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,7 @@
  * Move documentation generators to ContractHelpers
  * Display message for empty parameters or return types
  * `Ethers.call/2` and `Ethers.get_logs/2` now automatically convert integer block numbers to hex values
+ * Return structs as a result in generated functions and event filter with Inspection protocols implemented for better development experience
 
 ### Breaking Changes
 

--- a/lib/ethers/contract_helpers.ex
+++ b/lib/ethers/contract_helpers.ex
@@ -312,13 +312,6 @@ defmodule Ethers.ContractHelpers do
     |> Enum.zip_with(&(Enum.uniq(&1) |> Enum.join("_or_")))
   end
 
-  def maybe_add_to_address(map, module, field_name \\ :to) do
-    case module.__default_address__() do
-      nil -> map
-      address when is_binary(address) -> Map.put(map, field_name, address)
-    end
-  end
-
   def encode_event_topics(selector, args) do
     [event_topic_0(selector) | encode_event_sub_topics(selector, args)]
   end

--- a/lib/ethers/event_filter.ex
+++ b/lib/ethers/event_filter.ex
@@ -1,0 +1,49 @@
+defmodule Ethers.EventFilter do
+  @moduledoc """
+  Event Filter struct and helper functions to work with the event filters
+  """
+
+  @typedoc """
+  Holds event filter topics, the event selector and the default address.
+
+  Can be passed in to `Ethers.get_logs/2` filter and fetch the logs.
+  """
+  @type t :: %__MODULE__{
+          topics: [binary()],
+          selector: ABI.FunctionSelector.t(),
+          address: nil | Ethers.Types.t_address()
+        }
+
+  @enforce_keys [:topics, :selector]
+  defstruct [:topics, :selector, :address]
+
+  @doc false
+  @spec new([binary()], ABI.FunctionSelector.t(), Ethers.Types.t_address() | nil) :: t()
+  def new(topics, selector, address) do
+    %__MODULE__{
+      topics: topics,
+      selector: selector,
+      address: address
+    }
+  end
+
+  @doc false
+  @spec to_map(t() | map(), Keyword.t()) :: map()
+  def to_map(%__MODULE__{} = tx_data, overrides) do
+    tx_data
+    |> event_filter_map()
+    |> to_map(overrides)
+  end
+
+  def to_map(event_filter, overrides) do
+    Enum.into(overrides, event_filter)
+  end
+
+  defp event_filter_map(%{selector: %{type: :event}} = event_filter) do
+    %{topics: event_filter.topics}
+    |> maybe_add_address(event_filter.address)
+  end
+
+  defp maybe_add_address(tx_map, nil), do: tx_map
+  defp maybe_add_address(tx_map, address), do: Map.put(tx_map, :address, address)
+end

--- a/lib/ethers/event_filter.ex
+++ b/lib/ethers/event_filter.ex
@@ -11,19 +11,19 @@ defmodule Ethers.EventFilter do
   @type t :: %__MODULE__{
           topics: [binary()],
           selector: ABI.FunctionSelector.t(),
-          address: nil | Ethers.Types.t_address()
+          default_address: nil | Ethers.Types.t_address()
         }
 
   @enforce_keys [:topics, :selector]
-  defstruct [:topics, :selector, :address]
+  defstruct [:topics, :selector, :default_address]
 
   @doc false
   @spec new([binary()], ABI.FunctionSelector.t(), Ethers.Types.t_address() | nil) :: t()
-  def new(topics, selector, address) do
+  def new(topics, selector, default_address) do
     %__MODULE__{
       topics: topics,
       selector: selector,
-      address: address
+      default_address: default_address
     }
   end
 
@@ -41,9 +41,137 @@ defmodule Ethers.EventFilter do
 
   defp event_filter_map(%{selector: %{type: :event}} = event_filter) do
     %{topics: event_filter.topics}
-    |> maybe_add_address(event_filter.address)
+    |> maybe_add_address(event_filter.default_address)
   end
 
   defp maybe_add_address(tx_map, nil), do: tx_map
   defp maybe_add_address(tx_map, address), do: Map.put(tx_map, :address, address)
+
+  defimpl Inspect do
+    import Inspect.Algebra
+
+    alias Ethers.Utils
+
+    def inspect(
+          %{selector: selector, topics: [_t0 | topics], default_address: default_address},
+          opts
+        ) do
+      default_address =
+        case default_address do
+          nil ->
+            []
+
+          _ ->
+            [
+              line(),
+              color("default_address: ", :default, opts),
+              color(inspect(default_address), :string, opts)
+            ]
+        end
+
+      inner =
+        concat(
+          [
+            break(""),
+            color("event", :atom, opts),
+            " ",
+            color(selector.function, :call, opts),
+            color("(", :operator, opts),
+            nest(concat([break("") | argument_doc(selector, topics, opts)]), 2),
+            break(""),
+            color(")", :call, opts)
+          ] ++ default_address
+        )
+
+      concat([
+        color("#Ethers.EventFilter<", :map, opts),
+        nest(inner, 2),
+        break(""),
+        color(">", :map, opts)
+      ])
+    end
+
+    defp input_names(selector) do
+      if Enum.count(selector.types) == Enum.count(selector.input_names) do
+        selector.input_names
+      else
+        1..Enum.count(selector.types)
+        |> Enum.map(fn _ -> nil end)
+      end
+    end
+
+    defp argument_doc(selector, topics, opts),
+      do:
+        argument_doc(
+          selector.types,
+          input_names(selector),
+          selector.inputs_indexed,
+          topics,
+          [],
+          opts
+        )
+
+    defp argument_doc(types, input_names, inputs_indexed, topics, acc, opts)
+
+    defp argument_doc([], _, _, _, acc, opts) do
+      Enum.reverse(acc)
+      |> Enum.intersperse(concat(color(",", :operator, opts), break(" ")))
+    end
+
+    defp argument_doc(
+           [type | types],
+           [name | input_names],
+           [true | inputs_indexed],
+           [topic | topics],
+           acc,
+           opts
+         ) do
+      doc =
+        [
+          color(ABI.FunctionSelector.encode_type(type), :atom, opts),
+          " ",
+          color("indexed", nil, opts),
+          if(name, do: " "),
+          if(name, do: color(name, :variable, opts)),
+          " ",
+          if(is_nil(topic), do: color("any", :string, opts), else: human_topic(type, topic))
+        ]
+        |> Enum.reject(&is_nil/1)
+        |> concat()
+
+      argument_doc(types, input_names, inputs_indexed, topics, [doc | acc], opts)
+    end
+
+    defp argument_doc(
+           [type | types],
+           [name | input_names],
+           [false | inputs_indexed],
+           topics,
+           acc,
+           opts
+         ) do
+      doc =
+        [
+          color(ABI.FunctionSelector.encode_type(type), :atom, opts),
+          if(name, do: " "),
+          if(name, do: color(name, :variable, opts))
+        ]
+        |> Enum.reject(&is_nil/1)
+        |> concat()
+
+      argument_doc(types, input_names, inputs_indexed, topics, [doc | acc], opts)
+    end
+
+    defp human_topic(type, topic) when type in unquote(Ethers.Types.dynamically_sized_types()) do
+      "(hashed) #{inspect(topic)}"
+    end
+
+    defp human_topic(type, topic) do
+      [value] =
+        Utils.hex_decode!(topic)
+        |> ABI.TypeDecoder.decode([type])
+
+      inspect(Utils.human_arg(value, type))
+    end
+  end
 end

--- a/lib/ethers/tx_data.ex
+++ b/lib/ethers/tx_data.ex
@@ -1,0 +1,50 @@
+defmodule Ethers.TxData do
+  @moduledoc """
+  Transaction struct to hold information about the ABI selector, encoded data
+  and the target `to` address.
+  """
+
+  @typedoc """
+  Holds transaction data, the function selector and the default `to` address.
+
+  Can be passed in to `Ethers.call/2` or `Ethers.send/2` to execute.
+  """
+  @type t :: %__MODULE__{
+          data: binary() | [binary()],
+          selector: ABI.FunctionSelector.t(),
+          to: nil | Ethers.Types.t_address()
+        }
+
+  @enforce_keys [:data, :selector]
+  defstruct [:data, :selector, :to]
+
+  @doc false
+  @spec new(binary(), ABI.FunctionSelector.t(), Ethers.Types.t_address() | nil) :: t()
+  def new(data, selector, to) do
+    %__MODULE__{
+      data: data,
+      selector: selector,
+      to: to
+    }
+  end
+
+  @doc false
+  @spec to_map(t() | map(), Keyword.t()) :: map()
+  def to_map(%__MODULE__{} = tx_data, overrides) do
+    tx_data
+    |> get_tx_map()
+    |> to_map(overrides)
+  end
+
+  def to_map(tx_map, overrides) when is_map(tx_map) do
+    Enum.into(overrides, tx_map)
+  end
+
+  defp get_tx_map(%{selector: %{type: :function}} = tx_data) do
+    %{data: tx_data.data}
+    |> maybe_add_to_address(tx_data.to)
+  end
+
+  defp maybe_add_to_address(tx_map, nil), do: tx_map
+  defp maybe_add_to_address(tx_map, address), do: Map.put(tx_map, :to, address)
+end

--- a/lib/ethers/tx_data.ex
+++ b/lib/ethers/tx_data.ex
@@ -73,19 +73,39 @@ defmodule Ethers.TxData do
         end)
         |> Enum.intersperse(concat(color(",", :operator, opts), break(" ")))
 
+      returns =
+        Enum.map(selector.returns, &color(ABI.FunctionSelector.encode_type(&1), :atom, opts))
+        |> Enum.intersperse(concat(color(",", :operator, opts), break(" ")))
+
+      returns_doc =
+        if Enum.count(returns) > 0 do
+          [
+            break(" "),
+            color("returns ", :atom, opts),
+            color("(", :operator, opts),
+            nest(concat([break("") | returns]), 2),
+            break(""),
+            color(")", :operator, opts)
+          ]
+        else
+          []
+        end
+
       inner =
-        concat([
-          break(""),
-          color("function", :atom, opts),
-          " ",
-          color(selector.function, :call, opts),
-          color("(", :operator, opts),
-          nest(concat([break("") | arguments_doc]), 2),
-          break(""),
-          color(")", :call, opts),
-          " ",
-          state_mutability(selector, opts)
-        ])
+        concat(
+          [
+            break(""),
+            color("function", :atom, opts),
+            " ",
+            color(selector.function, :call, opts),
+            color("(", :operator, opts),
+            nest(concat([break("") | arguments_doc]), 2),
+            break(""),
+            color(")", :call, opts),
+            " ",
+            state_mutability(selector, opts)
+          ] ++ returns_doc
+        )
 
       concat([
         color("#Ethers.TxData<", :map, opts),

--- a/lib/ethers/tx_data.ex
+++ b/lib/ethers/tx_data.ex
@@ -59,8 +59,6 @@ defmodule Ethers.TxData do
       arguments_doc =
         Enum.zip([selector.types, input_names(selector), arguments])
         |> Enum.map(fn {type, name, arg} ->
-          Utils.human_arg(arg, type)
-
           [
             color(ABI.FunctionSelector.encode_type(type), :atom, opts),
             " ",

--- a/test/ethers/contract_helpers_test.exs
+++ b/test/ethers/contract_helpers_test.exs
@@ -77,16 +77,6 @@ defmodule Ethers.ContractHelpersTest do
                })
     end
   end
-
-  describe "maybe_add_to_address" do
-    test "adds to address if contract has default address" do
-      assert %{to: "0x"} == ContractHelpers.maybe_add_to_address(%{}, Ethers.WithDefaultAddress)
-    end
-
-    test "does not add to address if contract doesn't have a default one" do
-      assert %{} == ContractHelpers.maybe_add_to_address(%{}, Ethers.WithoutDefaultAddress)
-    end
-  end
 end
 
 defmodule Ethers.WithDefaultAddress do

--- a/test/ethers/contract_helpers_test.exs
+++ b/test/ethers/contract_helpers_test.exs
@@ -78,11 +78,3 @@ defmodule Ethers.ContractHelpersTest do
     end
   end
 end
-
-defmodule Ethers.WithDefaultAddress do
-  def __default_address__, do: "0x"
-end
-
-defmodule Ethers.WithoutDefaultAddress do
-  def __default_address__, do: nil
-end

--- a/test/ethers/counter_contract_test.exs
+++ b/test/ethers/counter_contract_test.exs
@@ -43,6 +43,15 @@ defmodule Ethers.CounterContractTest do
       assert "#Ethers.TxData<function set(uint256 101) non_payable>" ==
                inspect(put_in(tx_data.selector.input_names, ["invalid", "names", "length"]))
     end
+
+    test "includes default address if given" do
+      tx_data = CounterContract.get()
+
+      tx_data_with_default_address = %{tx_data | default_address: @from}
+
+      assert "#Ethers.TxData<function get() view returns (uint256)\n  default_address: \"0x90F8bf6A479f320ead074411a4B0e7944Ea8c9C1\">" ==
+               inspect(tx_data_with_default_address)
+    end
   end
 
   describe "calling functions" do
@@ -61,7 +70,7 @@ defmodule Ethers.CounterContractTest do
                  types: [],
                  returns: [uint: 256]
                },
-               to: nil
+               default_address: nil
              } == CounterContract.get()
 
       assert {:ok, [100]} = CounterContract.get() |> Ethers.call(to: address)
@@ -137,7 +146,7 @@ defmodule Ethers.CounterContractTest do
                  types: [uint: 256],
                  returns: []
                },
-               to: nil
+               default_address: nil
              } == CounterContract.set(101)
     end
   end

--- a/test/ethers/counter_contract_test.exs
+++ b/test/ethers/counter_contract_test.exs
@@ -25,7 +25,7 @@ defmodule Ethers.CounterContractTest do
     setup :deploy_counter_contract
 
     test "calling view functions", %{address: address} do
-      assert %{
+      assert %Ethers.TxData{
                data: "0x6d4ce63c",
                selector: %ABI.FunctionSelector{
                  function: "get",
@@ -36,7 +36,8 @@ defmodule Ethers.CounterContractTest do
                  input_names: [],
                  types: [],
                  returns: [uint: 256]
-               }
+               },
+               to: nil
              } == CounterContract.get()
 
       assert {:ok, [100]} = CounterContract.get() |> Ethers.call(to: address)
@@ -100,7 +101,7 @@ defmodule Ethers.CounterContractTest do
     end
 
     test "returns the params when called" do
-      assert %{
+      assert %Ethers.TxData{
                data: "0x60fe47b10000000000000000000000000000000000000000000000000000000000000065",
                selector: %ABI.FunctionSelector{
                  function: "set",
@@ -111,7 +112,8 @@ defmodule Ethers.CounterContractTest do
                  input_names: ["newAmount"],
                  types: [uint: 256],
                  returns: []
-               }
+               },
+               to: nil
              } == CounterContract.set(101)
     end
   end

--- a/test/ethers/counter_contract_test.exs
+++ b/test/ethers/counter_contract_test.exs
@@ -49,7 +49,7 @@ defmodule Ethers.CounterContractTest do
 
       tx_data_with_default_address = %{tx_data | default_address: @from}
 
-      assert "#Ethers.TxData<function get() view returns (uint256)\n  default_address: \"0x90F8bf6A479f320ead074411a4B0e7944Ea8c9C1\">" ==
+      assert ~s'#Ethers.TxData<function get() view returns (uint256)\n  default_address: "0x90F8bf6A479f320ead074411a4B0e7944Ea8c9C1">' ==
                inspect(tx_data_with_default_address)
     end
   end
@@ -80,7 +80,7 @@ defmodule Ethers.CounterContractTest do
 
       filter_with_default_address = %{filter | default_address: @from}
 
-      assert "#Ethers.EventFilter<event SetCalled(uint256 indexed oldAmount 101, uint256 newAmount)\n  default_address: \"0x90F8bf6A479f320ead074411a4B0e7944Ea8c9C1\">" ==
+      assert ~s'#Ethers.EventFilter<event SetCalled(uint256 indexed oldAmount 101, uint256 newAmount)\n  default_address: "0x90F8bf6A479f320ead074411a4B0e7944Ea8c9C1">' ==
                inspect(filter_with_default_address)
     end
   end

--- a/test/ethers/counter_contract_test.exs
+++ b/test/ethers/counter_contract_test.exs
@@ -21,6 +21,29 @@ defmodule Ethers.CounterContractTest do
     end
   end
 
+  describe "inspecting function calls" do
+    test "renders the correct values when inspected" do
+      assert "#Ethers.TxData<function get() view>" == inspect(CounterContract.get())
+
+      assert "#Ethers.TxData<function set(uint256 newAmount 101) non_payable>" ==
+               inspect(CounterContract.set(101))
+    end
+
+    test "shows unknown state mutability correctly" do
+      tx_data = CounterContract.get()
+
+      assert "#Ethers.TxData<function get() unknown>" ==
+               inspect(put_in(tx_data.selector.state_mutability, nil))
+    end
+
+    test "skips argument names in case of length mismatch" do
+      tx_data = CounterContract.set(101)
+
+      assert "#Ethers.TxData<function set(uint256 101) non_payable>" ==
+               inspect(put_in(tx_data.selector.input_names, ["invalid", "names", "length"]))
+    end
+  end
+
   describe "calling functions" do
     setup :deploy_counter_contract
 

--- a/test/ethers/counter_contract_test.exs
+++ b/test/ethers/counter_contract_test.exs
@@ -23,7 +23,8 @@ defmodule Ethers.CounterContractTest do
 
   describe "inspecting function calls" do
     test "renders the correct values when inspected" do
-      assert "#Ethers.TxData<function get() view>" == inspect(CounterContract.get())
+      assert "#Ethers.TxData<function get() view returns (uint256)>" ==
+               inspect(CounterContract.get())
 
       assert "#Ethers.TxData<function set(uint256 newAmount 101) non_payable>" ==
                inspect(CounterContract.set(101))
@@ -32,7 +33,7 @@ defmodule Ethers.CounterContractTest do
     test "shows unknown state mutability correctly" do
       tx_data = CounterContract.get()
 
-      assert "#Ethers.TxData<function get() unknown>" ==
+      assert "#Ethers.TxData<function get() unknown returns (uint256)>" ==
                inspect(put_in(tx_data.selector.state_mutability, nil))
     end
 

--- a/test/ethers/counter_contract_test.exs
+++ b/test/ethers/counter_contract_test.exs
@@ -54,6 +54,37 @@ defmodule Ethers.CounterContractTest do
     end
   end
 
+  describe "inspecting event filters" do
+    test "renders the correct values when inspected" do
+      assert "#Ethers.EventFilter<event SetCalled(uint256 indexed oldAmount any, uint256 newAmount)>" ==
+               inspect(CounterContract.EventFilters.set_called(nil))
+
+      assert "#Ethers.EventFilter<event SetCalled(uint256 indexed oldAmount 101, uint256 newAmount)>" ==
+               inspect(CounterContract.EventFilters.set_called(101))
+    end
+
+    test "renders the correct values when input names are not provided or incorrect" do
+      filter = CounterContract.EventFilters.set_called(101)
+
+      assert "#Ethers.EventFilter<event SetCalled(uint256 indexed 101, uint256)>" ==
+               inspect(put_in(filter.selector.input_names, []))
+
+      assert "#Ethers.EventFilter<event SetCalled(uint256 indexed 101, uint256)>" ==
+               inspect(
+                 put_in(filter.selector.input_names, filter.selector.input_names ++ ["invalid"])
+               )
+    end
+
+    test "includes default address if given" do
+      filter = CounterContract.EventFilters.set_called(101)
+
+      filter_with_default_address = %{filter | default_address: @from}
+
+      assert "#Ethers.EventFilter<event SetCalled(uint256 indexed oldAmount 101, uint256 newAmount)\n  default_address: \"0x90F8bf6A479f320ead074411a4B0e7944Ea8c9C1\">" ==
+               inspect(filter_with_default_address)
+    end
+  end
+
   describe "calling functions" do
     setup :deploy_counter_contract
 

--- a/test/ethers/event_mixed_index_contract_test.exs
+++ b/test/ethers/event_mixed_index_contract_test.exs
@@ -62,7 +62,7 @@ defmodule Ethers.EventMixedIndexContractTest do
     end
 
     test "inspect returns correct value" do
-      assert "#Ethers.EventFilter<event Transfer(uint256 amount, address indexed sender \"0x90f8bf6a479f320ead074411a4b0e7944ea80000\", bool isFinal, address indexed receiver \"0x90f8bf6a479f320ead074411a4b0e7944ea80001\")>" ==
+      assert ~s'#Ethers.EventFilter<event Transfer(uint256 amount, address indexed sender "0x90f8bf6a479f320ead074411a4b0e7944ea80000", bool isFinal, address indexed receiver "0x90f8bf6a479f320ead074411a4b0e7944ea80001")>' ==
                inspect(
                  EventMixedIndexContract.EventFilters.transfer(
                    "0x90f8bf6a479f320ead074411a4b0e7944ea80000",
@@ -70,7 +70,7 @@ defmodule Ethers.EventMixedIndexContractTest do
                  )
                )
 
-      assert "#Ethers.EventFilter<event Transfer(uint256 amount, address indexed sender any, bool isFinal, address indexed receiver \"0x90f8bf6a479f320ead074411a4b0e7944ea80001\")>" ==
+      assert ~s'#Ethers.EventFilter<event Transfer(uint256 amount, address indexed sender any, bool isFinal, address indexed receiver "0x90f8bf6a479f320ead074411a4b0e7944ea80001")>' ==
                inspect(
                  EventMixedIndexContract.EventFilters.transfer(
                    nil,

--- a/test/ethers/event_mixed_index_contract_test.exs
+++ b/test/ethers/event_mixed_index_contract_test.exs
@@ -28,7 +28,7 @@ defmodule Ethers.EventMixedIndexContractTest do
                  "0x00000000000000000000000090f8bf6a479f320ead074411a4b0e7944ea8c9c1",
                  "0x00000000000000000000000090f8bf6a479f320ead074411a4b0e7944ea8c9c1"
                ],
-               address: nil
+               default_address: nil
              } == EventMixedIndexContract.EventFilters.transfer(@from, @from)
     end
 
@@ -59,6 +59,24 @@ defmodule Ethers.EventMixedIndexContractTest do
                    "0x00000000000000000000000000000000000000000000000000000000000000640000000000000000000000000000000000000000000000000000000000000001"
                }
              ] = Ethers.get_logs!(filter)
+    end
+
+    test "inspect returns correct value" do
+      assert "#Ethers.EventFilter<event Transfer(uint256 amount, address indexed sender \"0x90f8bf6a479f320ead074411a4b0e7944ea80000\", bool isFinal, address indexed receiver \"0x90f8bf6a479f320ead074411a4b0e7944ea80001\")>" ==
+               inspect(
+                 EventMixedIndexContract.EventFilters.transfer(
+                   "0x90f8bf6a479f320ead074411a4b0e7944ea80000",
+                   "0x90f8bf6a479f320ead074411a4b0e7944ea80001"
+                 )
+               )
+
+      assert "#Ethers.EventFilter<event Transfer(uint256 amount, address indexed sender any, bool isFinal, address indexed receiver \"0x90f8bf6a479f320ead074411a4b0e7944ea80001\")>" ==
+               inspect(
+                 EventMixedIndexContract.EventFilters.transfer(
+                   nil,
+                   "0x90f8bf6a479f320ead074411a4b0e7944ea80001"
+                 )
+               )
     end
   end
 end

--- a/test/ethers/event_mixed_index_contract_test.exs
+++ b/test/ethers/event_mixed_index_contract_test.exs
@@ -12,7 +12,7 @@ defmodule Ethers.EventMixedIndexContractTest do
 
   describe "event filters" do
     test "works with mixed indexed events" do
-      assert %{
+      assert %Ethers.EventFilter{
                selector: %ABI.FunctionSelector{
                  function: "Transfer",
                  method_id: <<15, 20, 89, 183>>,
@@ -27,7 +27,8 @@ defmodule Ethers.EventMixedIndexContractTest do
                  "0x0f1459b71050cedb12633644ebaa16569e1bb49626ab8a0f4c7d1cf0d574abe7",
                  "0x00000000000000000000000090f8bf6a479f320ead074411a4b0e7944ea8c9c1",
                  "0x00000000000000000000000090f8bf6a479f320ead074411a4b0e7944ea8c9c1"
-               ]
+               ],
+               address: nil
              } == EventMixedIndexContract.EventFilters.transfer(@from, @from)
     end
 

--- a/test/ethers/multi_clause_contract_test.exs
+++ b/test/ethers/multi_clause_contract_test.exs
@@ -106,6 +106,20 @@ defmodule Ethers.MultiClauseContractTest do
                      MultiClauseContract.EventFilters.multi_event(10)
                    end
     end
+
+    test "renders correct values when inspected" do
+      uint_filter = MultiClauseContract.EventFilters.multi_event(typed({:uint, 256}, nil))
+      int_filter = MultiClauseContract.EventFilters.multi_event(-30)
+      string_filter = MultiClauseContract.EventFilters.multi_event("value to filter")
+
+      assert "#Ethers.EventFilter<event MultiEvent(uint256 indexed n any)>" ==
+               inspect(uint_filter)
+
+      assert "#Ethers.EventFilter<event MultiEvent(int256 indexed n -30)>" == inspect(int_filter)
+
+      assert "#Ethers.EventFilter<event MultiEvent(string indexed n (hashed) \"0xa842b64ae579814ab0eb0812f6cf54815c20796d31e248113583d3cf17d7eef4\")>" ==
+               inspect(string_filter)
+    end
   end
 
   defp deploy_multi_clause_contract(_ctx) do

--- a/test/ethers/multi_clause_contract_test.exs
+++ b/test/ethers/multi_clause_contract_test.exs
@@ -101,7 +101,7 @@ defmodule Ethers.MultiClauseContractTest do
 
     test "raises on conflicting parameters" do
       assert_raise ArgumentError,
-                   "Ambiguous parameters\n\n## Arguments\n~c\"\\n\"\n\n## Possible signatures\nMultiEvent(uint256 n)\nMultiEvent(int256 n)\n",
+                   ~s'Ambiguous parameters\n\n## Arguments\n~c"\\n"\n\n## Possible signatures\nMultiEvent(uint256 n)\nMultiEvent(int256 n)\n',
                    fn ->
                      MultiClauseContract.EventFilters.multi_event(10)
                    end
@@ -117,7 +117,7 @@ defmodule Ethers.MultiClauseContractTest do
 
       assert "#Ethers.EventFilter<event MultiEvent(int256 indexed n -30)>" == inspect(int_filter)
 
-      assert "#Ethers.EventFilter<event MultiEvent(string indexed n (hashed) \"0xa842b64ae579814ab0eb0812f6cf54815c20796d31e248113583d3cf17d7eef4\")>" ==
+      assert ~s'#Ethers.EventFilter<event MultiEvent(string indexed n (hashed) "0xa842b64ae579814ab0eb0812f6cf54815c20796d31e248113583d3cf17d7eef4")>' ==
                inspect(string_filter)
     end
   end

--- a/test/ethers_test.exs
+++ b/test/ethers_test.exs
@@ -164,7 +164,7 @@ defmodule EthersTest do
                  types: [:string],
                  returns: []
                },
-               address: "0x1000bf6a479f320ead074411a4b0e7944ea8c9c1"
+               default_address: "0x1000bf6a479f320ead074411a4b0e7944ea8c9c1"
              } == HelloWorldWithDefaultAddressContract.EventFilters.hello_set()
 
       assert %{
@@ -190,7 +190,7 @@ defmodule EthersTest do
                  types: [:string],
                  returns: []
                },
-               address: nil
+               default_address: nil
              } == HelloWorldContract.EventFilters.hello_set()
     end
   end

--- a/test/ethers_test.exs
+++ b/test/ethers_test.exs
@@ -124,7 +124,7 @@ defmodule EthersTest do
                  types: [],
                  returns: [:string]
                },
-               to: "0x1000bf6a479f320ead074411a4b0e7944ea8c9c1"
+               default_address: "0x1000bf6a479f320ead074411a4b0e7944ea8c9c1"
              } == HelloWorldWithDefaultAddressContract.say_hello()
 
       assert %{data: "0xef5fb05b", to: "0x1000bf6a479f320ead074411a4b0e7944ea8c9c1"} ==
@@ -145,7 +145,7 @@ defmodule EthersTest do
                  types: [],
                  returns: [:string]
                },
-               to: nil
+               default_address: nil
              } == HelloWorldContract.say_hello()
     end
 

--- a/test/ethers_test.exs
+++ b/test/ethers_test.exs
@@ -3,11 +3,19 @@ defmodule Ethers.Contract.Test.HelloWorldContract do
   use Ethers.Contract, abi_file: "tmp/hello_world_abi.json"
 end
 
+defmodule Ethers.Contract.Test.HelloWorldWithDefaultAddressContract do
+  @moduledoc false
+  use Ethers.Contract,
+    abi_file: "tmp/hello_world_abi.json",
+    default_address: "0x1000bf6a479f320ead074411a4b0e7944ea8c9c1"
+end
+
 defmodule EthersTest do
   use ExUnit.Case
   doctest Ethers
 
   alias Ethers.Contract.Test.HelloWorldContract
+  alias Ethers.Contract.Test.HelloWorldWithDefaultAddressContract
 
   @from "0x90f8bf6a479f320ead074411a4b0e7944ea8c9c1"
 
@@ -99,6 +107,91 @@ defmodule EthersTest do
           rpc_opts: [url: "http://non.exists"]
         )
       end
+    end
+  end
+
+  describe "default address" do
+    test "is included in the function calls when has default address" do
+      assert %Ethers.TxData{
+               data: "0xef5fb05b",
+               selector: %ABI.FunctionSelector{
+                 function: "sayHello",
+                 method_id: <<239, 95, 176, 91>>,
+                 type: :function,
+                 inputs_indexed: nil,
+                 state_mutability: :view,
+                 input_names: [],
+                 types: [],
+                 returns: [:string]
+               },
+               to: "0x1000bf6a479f320ead074411a4b0e7944ea8c9c1"
+             } == HelloWorldWithDefaultAddressContract.say_hello()
+
+      assert %{data: "0xef5fb05b", to: "0x1000bf6a479f320ead074411a4b0e7944ea8c9c1"} ==
+               HelloWorldWithDefaultAddressContract.say_hello()
+               |> Ethers.TxData.to_map([])
+    end
+
+    test "is not included in the function calls when does not have default address" do
+      assert %Ethers.TxData{
+               data: "0xef5fb05b",
+               selector: %ABI.FunctionSelector{
+                 function: "sayHello",
+                 method_id: <<239, 95, 176, 91>>,
+                 type: :function,
+                 inputs_indexed: nil,
+                 state_mutability: :view,
+                 input_names: [],
+                 types: [],
+                 returns: [:string]
+               },
+               to: nil
+             } == HelloWorldContract.say_hello()
+    end
+
+    test "is included in event filters when has default address" do
+      assert %Ethers.EventFilter{
+               topics: [
+                 "0xbe6cf5e99b344c66895d6304d442b2f51b6359ee51ac581db2255de9373e24b8"
+               ],
+               selector: %ABI.FunctionSelector{
+                 function: "HelloSet",
+                 method_id: <<190, 108, 245, 233>>,
+                 type: :event,
+                 inputs_indexed: [false],
+                 state_mutability: nil,
+                 input_names: ["message"],
+                 types: [:string],
+                 returns: []
+               },
+               address: "0x1000bf6a479f320ead074411a4b0e7944ea8c9c1"
+             } == HelloWorldWithDefaultAddressContract.EventFilters.hello_set()
+
+      assert %{
+               topics: ["0xbe6cf5e99b344c66895d6304d442b2f51b6359ee51ac581db2255de9373e24b8"],
+               address: "0x1000bf6a479f320ead074411a4b0e7944ea8c9c1"
+             } ==
+               HelloWorldWithDefaultAddressContract.EventFilters.hello_set()
+               |> Ethers.EventFilter.to_map([])
+    end
+
+    test "is not included in event filters when does not have default address" do
+      assert %Ethers.EventFilter{
+               topics: [
+                 "0xbe6cf5e99b344c66895d6304d442b2f51b6359ee51ac581db2255de9373e24b8"
+               ],
+               selector: %ABI.FunctionSelector{
+                 function: "HelloSet",
+                 method_id: <<190, 108, 245, 233>>,
+                 type: :event,
+                 inputs_indexed: [false],
+                 state_mutability: nil,
+                 input_names: ["message"],
+                 types: [:string],
+                 returns: []
+               },
+               address: nil
+             } == HelloWorldContract.EventFilters.hello_set()
     end
   end
 end

--- a/test/support/contracts/hello_world.sol
+++ b/test/support/contracts/hello_world.sol
@@ -9,6 +9,9 @@ contract HelloWorld {
     }
 
     function setHello(string calldata message) external {
+        emit HelloSet(message);
         str = message;
     }
+
+    event HelloSet(string message);
 }


### PR DESCRIPTION
Implemented `Ethers.TxData` and `Ethers.EventFilter` structs to help with the development experience of Ethers users.

Both these structs implement Inspect protocol and render nice results when inspected.