### PR TITLE
Fix integer encoding in parameters of transactions

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Changelog
 
+## Unreleased
+
+### Bug fixes
+
+- Encode integers to hex even when they are part of params
+
 ## v0.2.0 (2024-01-01)
 
 ### New Features
@@ -12,7 +18,7 @@
 
 ## v0.1.3 (2023-12-26)
 
-## Bug fixes
+### Bug fixes
 
 - unsized integer encoding to hex will now raise if given negative numbers.
 - `Utils.date_to_block_number/3` going to negative block numbers issue fixed.

--- a/lib/ethers/tx_data.ex
+++ b/lib/ethers/tx_data.ex
@@ -37,11 +37,12 @@ defmodule Ethers.TxData do
   end
 
   def to_map(tx_map, overrides) when is_map(tx_map) do
-    Enum.map(overrides, fn
+    overrides
+    |> Enum.into(tx_map)
+    |> Map.new(fn
       {k, v} when is_integer(v) -> {k, Ethers.Utils.integer_to_hex(v)}
       kv -> kv
     end)
-    |> Enum.into(tx_map)
   end
 
   defp get_tx_map(%{selector: %{type: :function}} = tx_data) do

--- a/test/ethers_test.exs
+++ b/test/ethers_test.exs
@@ -314,6 +314,24 @@ defmodule EthersTest do
       assert {:ok, "hello local signer"} =
                Ethers.call(HelloWorldContract.say_hello(), to: address)
     end
+
+    test "converts all integer params and overrides to hex" do
+      assert {:ok, _tx_hash} =
+               Ethers.send(
+                 %{value: 1000},
+                 rpc_client: Ethers.TestRPCModule,
+                 from: @from,
+                 to: "0x95cED938F7991cd0dFcb48F0a06a40FA1aF46EBC",
+                 rpc_opts: [send_params_to_pid: self()]
+               )
+
+      assert_receive %{
+        from: "0x90f8bf6a479f320ead074411a4b0e7944ea8c9c1",
+        gas: "0x119",
+        to: "0x95cED938F7991cd0dFcb48F0a06a40FA1aF46EBC",
+        value: "0x3E8"
+      }
+    end
   end
 
   describe "sign_transaction/2" do

--- a/test/support/test_rpc_module.ex
+++ b/test/support/test_rpc_module.ex
@@ -7,8 +7,12 @@ defmodule Ethers.TestRPCModule do
     {:ok, "0x100"}
   end
 
-  def eth_send_transaction(_params, _opts) do
-    {:ok, "tx_hash"}
+  def eth_send_transaction(params, opts) do
+    if pid = opts[:send_params_to_pid] do
+      send(pid, params)
+    end
+
+    {:ok, opts[:tx_hash] || "tx_hash"}
   end
 
   def eth_call(params, block, opts) do


### PR DESCRIPTION
When encoding integers, we used to encode them to their hexadecimal value with 0x prefix when they were part of overrides. But this did not include params as sometimes it makes sense to just manually change/set them.

For example, when we want to move ETH (native currency), somebody might specify it in params like this:

```elixir
Ethers.send(%{value: 1000}, from: "0xab...ef", to: "0xef..ab")
```

If we don't convert `value` to hex then some execution clients will not accept it as it is not per standard.

This PR fixes this issue by converting all integer values to hex.