### PR TITLE
fix: event filter typespec generation for events with interleaved indexed and non-indexed fields

### DIFF
--- a/lib/ethers/contract.ex
+++ b/lib/ethers/contract.ex
@@ -277,7 +277,7 @@ defmodule Ethers.Contract do
 
     func_args = generate_arguments(mod, abi.arity, aggregated_input_names)
 
-    func_typespec = generate_event_typespecs(abi.selectors, abi.arity)
+    func_typespec = generate_event_typespecs(abi.selectors)
 
     quote context: mod, location: :keep do
       if unquote(generate_docs?(name, opts[:skip_docs])) do

--- a/lib/ethers/contract_helpers.ex
+++ b/lib/ethers/contract_helpers.ex
@@ -217,8 +217,8 @@ defmodule Ethers.ContractHelpers do
     |> do_generate_typescpecs()
   end
 
-  def generate_event_typespecs(selectors, arity) do
-    Enum.map(selectors, &Enum.take(&1.types, arity))
+  def generate_event_typespecs(selectors) do
+    Enum.map(selectors, &event_indexed_types/1)
     |> do_generate_typescpecs(true)
   end
 

--- a/test/ethers/contract_helpers_test.exs
+++ b/test/ethers/contract_helpers_test.exs
@@ -61,6 +61,28 @@ defmodule Ethers.ContractHelpersTest do
     end
   end
 
+  describe "generate_event_typespecs" do
+    test "uses indexed field types when indexed and non-indexed fields are interleaved" do
+      # Transfer(uint256 amount, address indexed sender, bool isFinal, address indexed receiver)
+      # from test/support/contracts/event_mixed_index.sol
+      selector = %ABI.FunctionSelector{
+        function: "Transfer",
+        type: :event,
+        types: [{:uint, 256}, :address, :bool, :address],
+        inputs_indexed: [false, true, false, true],
+        input_names: ["amount", "sender", "isFinal", "receiver"],
+        returns: []
+      }
+
+      [sender_type, receiver_type] = ContractHelpers.generate_event_typespecs([selector])
+      address_typespec = Ethers.Types.to_elixir_type(:address)
+
+      # Both indexed params are address, so both typespecs should be t_address() | nil.
+      assert sender_type == quote(do: unquote(address_typespec) | nil)
+      assert receiver_type == quote(do: unquote(address_typespec) | nil)
+    end
+  end
+
   describe "human_signature" do
     test "returns the human signature of a given function" do
       assert "name(uint256 id, address address)" ==


### PR DESCRIPTION
### Description

The `generate_event_typespecs` function calls `Enum.take(selector.types, arity)` to extract the types of the indexed fields from an event selector. The problem with this is that `Enum.take(selector.types, arity)` grabs the first `arity` types from the full ABI field list, but when an event has interleaved indexed and non-indexed fields, this produces wrong typespecs (the generated spec contains the type of a non-indexed field instead of the actual indexed field).

#### Example

Take for example the following event

```solidity
event Transfer(uint256 amount, address indexed sender, bool isFinal, address indexed receiver)
```

The arity of this event is 2 (there are 2 indexed fields), so in this case the `generate_event_typespecs` function will select the first 2 fields to determine the type of the indexed fields.

As a result, the `generate_event_typespecs` function will return `[uint256, address]`. However, the types of the indexed fields are actually `[address, address]`.


This PR fixes this error by updating the `generate_event_typespecs` function so that it uses the `event_indexed_types` function to select the types for the event typespec. This ensures the typespec is generated with the right types.